### PR TITLE
Extend default name generation

### DIFF
--- a/opvious/modeling/identifiers.py
+++ b/opvious/modeling/identifiers.py
@@ -240,23 +240,22 @@ class DefaultIdentifierFormatter(IdentifierFormatter):
 
     def _format_dimension(self, label: Label, env: Environment) -> Name:
         i = _last_capital_index(label)
-        if i is None:
-            return _first_available(label[0].upper(), env)
-        return f"{label[i]}^\\mathrm{{{label[:i]}}}" if i > 0 else label[i]
+        r = label[i or 0].upper()
+        n = r if i is None else f"{r}^\\mathrm{{{label[:i]}}}"
+        return _first_available(n, env)
 
     def _format_parameter(self, label: Label, env: Environment) -> Name:
         i = _last_capital_index(label)
-        if not i:
-            return _first_available(label[0].lower(), env)
-        return f"{label[i].lower()}^\\mathrm{{{label[:i]}}}"
+        r = label[i or 0].lower()
+        n = r if i is None else f"{r}^\\mathrm{{{label[:i]}}}"
+        return _first_available(n, env)
 
     def _format_variable(self, label: Label, env: Environment) -> Name:
         i = _last_capital_index(label)
         r = label[i or 0].lower()
         g = _greek_letters.get(r, r)
-        if not i:
-            return _first_available(g, env)
-        return f"{g}^\\mathrm{{{label[:i]}}}"
+        n = g if i is None else f"{g}^\\mathrm{{{label[:i]}}}"
+        return _first_available(n, env)
 
     def format_quantifier(
         self, identifier: QuantifierIdentifier, env: Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "opvious"
-version = "0.17.1rc1"
+version = "0.17.2rc1"
 description = "Opvious Python SDK"
 authors = ["Opvious Engineering <oss@opvious.io>"]
 readme = "README.md"

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -251,6 +251,22 @@ class TestModeling:
         assert counts["PARAMETER"].iloc[0] == 4
 
     @pytest.mark.asyncio
+    async def test_global_name_collision(self):
+        class _Model(om.Model):
+            step_count = om.Variable.natural()
+            step_cost = om.Variable.non_negative()
+            step_color = om.Variable.non_negative()
+
+            @om.objective
+            def minimize_cost(self):
+                return self.step_count() + self.step_cost() + self.step_color()
+
+        model = _Model()
+        spec = await client.annotate_specification(model.specification())
+        assert spec.annotation.issue_count == 0
+        assert r"\chi^\mathrm{step}''" in spec.sources[0].text
+
+    @pytest.mark.asyncio
     async def test_annotate_markdown_repr(self):
         model = InvalidSetCoverModel()
         spec = await client.annotate_specification(model.specification())


### PR DESCRIPTION
The default auto-naming logic will now resolve collisions (by appending `'`s as needed). For example:

```python
class Example(om.Model):
    step_count = om.Variable.natural() # \chi^\mathrm{step}
    step_cost = om.Variable.non_negative() # \chi^\mathrm{step}'
    step_color = om.Variable.non_negative() # \chi^\mathrm{step}''
```

Previously all variables in this example would have been named `\chi^\mathrm{step}` requiring users to add explicit names.